### PR TITLE
Feat : 주문 상태 모아보기

### DIFF
--- a/src/main/java/com/mypill/domain/buyer/controller/BuyerController.java
+++ b/src/main/java/com/mypill/domain/buyer/controller/BuyerController.java
@@ -7,6 +7,8 @@ import com.mypill.domain.comment.entity.Comment;
 import com.mypill.domain.comment.service.CommentService;
 import com.mypill.domain.order.dto.response.OrderListResponse;
 import com.mypill.domain.order.entity.Order;
+import com.mypill.domain.order.entity.OrderItem;
+import com.mypill.domain.order.entity.OrderStatus;
 import com.mypill.domain.order.service.OrderService;
 import com.mypill.domain.post.entity.Post;
 import com.mypill.domain.post.service.PostService;
@@ -18,8 +20,11 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Controller
 @RequiredArgsConstructor
@@ -80,6 +85,17 @@ public class BuyerController {
                 .sorted(Comparator.comparing((Order order) -> order.getPayment().getPayDate()).reversed())
                 .map(OrderListResponse::of).toList();
         model.addAttribute("orders", orderListResponses);
+
+        List<OrderItem> orderItems = orderService.findOrderItemByBuyerId(rq.getMember().getId());
+        Map<OrderStatus, Long> orderStatusCount = orderItems.stream()
+                .collect(Collectors.groupingBy(OrderItem::getStatus, Collectors.counting()));
+
+        model.addAttribute("orderStatusCount", orderStatusCount);
+
+        OrderStatus[] filteredOrderStatus = Arrays.stream(OrderStatus.values())
+                .filter(status -> status.getPriority() >=1 && status.getPriority() <= 4 )
+                .toArray(OrderStatus[]::new);
+        model.addAttribute("orderStatuses", filteredOrderStatus);
 
         return "usr/buyer/myOrder";
     }

--- a/src/main/java/com/mypill/domain/buyer/controller/BuyerController.java
+++ b/src/main/java/com/mypill/domain/buyer/controller/BuyerController.java
@@ -18,6 +18,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Controller
@@ -75,7 +76,9 @@ public class BuyerController {
     public String myOrder(Model model) {
 
         List<Order> orders = orderService.findByBuyerId(rq.getMember().getId());
-        List<OrderListResponse> orderListResponses = orders.stream().map(OrderListResponse::of).toList();
+        List<OrderListResponse> orderListResponses = orders.stream()
+                .sorted(Comparator.comparing((Order order) -> order.getPayment().getPayDate()).reversed())
+                .map(OrderListResponse::of).toList();
         model.addAttribute("orders", orderListResponses);
 
         return "usr/buyer/myOrder";

--- a/src/main/java/com/mypill/domain/order/dto/response/OrderListResponse.java
+++ b/src/main/java/com/mypill/domain/order/dto/response/OrderListResponse.java
@@ -3,6 +3,7 @@ package com.mypill.domain.order.dto.response;
 import com.mypill.domain.address.entity.Address;
 import com.mypill.domain.order.entity.Order;
 import com.mypill.domain.order.entity.OrderItem;
+import com.mypill.domain.order.entity.OrderStatus;
 import com.mypill.domain.order.entity.Payment;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -20,6 +21,7 @@ public class OrderListResponse {
     private String name;
     private Long totalPrice;
     private Payment payment;
+    private OrderStatus primaryOrderStatus;
 
     public static OrderListResponse of(Order order){
         return OrderListResponse.builder()
@@ -28,6 +30,7 @@ public class OrderListResponse {
                 .name(order.getName())
                 .totalPrice(order.getTotalPrice())
                 .payment(order.getPayment())
+                .primaryOrderStatus(order.getPrimaryOrderStatus())
                 .build();
     }
 

--- a/src/main/java/com/mypill/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/mypill/domain/order/dto/response/OrderResponse.java
@@ -24,6 +24,7 @@ public class OrderResponse {
     private Long totalPrice;
     private Address deliveryAddress;
     private Payment payment;
+    private OrderStatus primaryOrderStatus;
 
     public static OrderResponse of(Order order){
         return OrderResponse.builder()
@@ -35,6 +36,7 @@ public class OrderResponse {
                 .totalPrice(order.getTotalPrice())
                 .deliveryAddress(order.getDeliveryAddress())
                 .payment(order.getPayment())
+                .primaryOrderStatus(order.getPrimaryOrderStatus())
                 .build();
     }
 

--- a/src/main/java/com/mypill/domain/order/entity/Order.java
+++ b/src/main/java/com/mypill/domain/order/entity/Order.java
@@ -45,6 +45,8 @@ public class Order extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Address deliveryAddress;
 
+    private OrderStatus primaryOrderStatus;
+
     public Order(Member buyer) {
         this.buyer = buyer;
         this.cartProducts = new ArrayList<>();
@@ -91,6 +93,10 @@ public class Order extends BaseEntity {
 
     public void updatePayment(String method, Long totalAmount, LocalDateTime payDate, String status) {
         this.payment = new Payment(method, totalAmount, status, payDate);
+    }
+
+    public void updatePrimaryOrderStatus(OrderStatus orderStatus){
+        this.primaryOrderStatus = orderStatus;
     }
 
 

--- a/src/main/java/com/mypill/domain/order/entity/Order.java
+++ b/src/main/java/com/mypill/domain/order/entity/Order.java
@@ -78,7 +78,7 @@ public class Order extends BaseEntity {
         }
 
         if (orderItems.size() > 1) {
-            sb.append(" 외 %d개".formatted(orderItems.size() - 1));
+            sb.append(" 외 %d".formatted(orderItems.size() - 1));
         }
 
         this.name = sb.toString();

--- a/src/main/java/com/mypill/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/mypill/domain/order/entity/OrderStatus.java
@@ -4,17 +4,18 @@ import lombok.Getter;
 
 @Getter
 public enum OrderStatus {
-    BEFORE("주문 전"),
-    ORDERED("결제 완료"),
-    PREPARING("상품 준비중"),
-    SHIPPING("배송 중"),
-    DELIVERED("배송 완료"),
-    CANCELED("주문 취소");
-
+    BEFORE("주문 전", 0),
+    ORDERED("결제 완료", 1),
+    PREPARING("상품 준비중", 2),
+    SHIPPING("배송 중", 3),
+    DELIVERED("배송 완료", 4),
+    CANCELED("주문 취소", 5);
     private String value;
+    private int priority;
 
-    OrderStatus(String value) {
+    OrderStatus(String value, int priority) {
         this.value = value;
+        this.priority = priority;
     }
 
     public static OrderStatus findByValue(String value) {

--- a/src/main/java/com/mypill/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/mypill/domain/order/repository/OrderItemRepository.java
@@ -3,5 +3,5 @@ package com.mypill.domain.order.repository;
 import com.mypill.domain.order.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
 }

--- a/src/main/java/com/mypill/domain/order/repository/OrderItemRepositoryCustom.java
+++ b/src/main/java/com/mypill/domain/order/repository/OrderItemRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.mypill.domain.order.repository;
+
+import com.mypill.domain.order.entity.OrderItem;
+
+import java.util.List;
+
+public interface OrderItemRepositoryCustom {
+    List<OrderItem> findBySellerId(Long sellerId);
+    List<OrderItem> findByBuyerId(Long buyerId);
+}

--- a/src/main/java/com/mypill/domain/order/repository/OrderItemRepositoryImpl.java
+++ b/src/main/java/com/mypill/domain/order/repository/OrderItemRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.mypill.domain.order.repository;
+
+import com.mypill.domain.order.entity.OrderItem;
+import com.mypill.domain.order.entity.OrderStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.mypill.domain.order.entity.QOrder.order;
+import static com.mypill.domain.order.entity.QOrderItem.orderItem;
+import static com.mypill.domain.product.entity.QProduct.product;
+
+@RequiredArgsConstructor
+public class OrderItemRepositoryImpl implements OrderItemRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<OrderItem> findBySellerId(Long sellerId){
+        return jpaQueryFactory.selectFrom(orderItem)
+                .join(orderItem.product, product)
+                .where(product.seller.id.eq(sellerId)
+                        .and(orderItem.status.ne(OrderStatus.BEFORE)))
+                .fetch();
+    }
+
+    @Override
+    public List<OrderItem> findByBuyerId(Long buyerId){
+        return jpaQueryFactory.selectFrom(orderItem)
+                .where(orderItem.order.buyer.id.eq(buyerId)
+                        .and(orderItem.status.ne(OrderStatus.BEFORE)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/mypill/domain/order/service/OrderService.java
+++ b/src/main/java/com/mypill/domain/order/service/OrderService.java
@@ -212,5 +212,11 @@ public class OrderService {
     public List<Order> findBySellerId(Long sellerId) {
         return orderRepository.findBySellerId(sellerId);
     }
+    public List<OrderItem> findOrderItemBySellerId(Long sellerId) {
+        return orderItemRepository.findBySellerId(sellerId);
+    }
+    public List<OrderItem> findOrderItemByBuyerId(Long buyerId) {
+        return orderItemRepository.findByBuyerId(buyerId);
+    }
 
 }

--- a/src/main/java/com/mypill/domain/seller/controller/SellerController.java
+++ b/src/main/java/com/mypill/domain/seller/controller/SellerController.java
@@ -1,6 +1,8 @@
 package com.mypill.domain.seller.controller;
 
 import com.mypill.domain.order.dto.response.OrderListResponse;
+import com.mypill.domain.order.entity.Order;
+import com.mypill.domain.order.entity.Payment;
 import com.mypill.domain.order.service.OrderService;
 import com.mypill.domain.seller.service.SellerService;
 import com.mypill.global.rq.Rq;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Controller
@@ -38,7 +41,10 @@ public class SellerController {
     @GetMapping("/order")
     public String orderManagement(Model model) {
         List<OrderListResponse> orderResponses = orderService.findBySellerId(rq.getMember().getId())
-                .stream().map(OrderListResponse::of).toList();
+                .stream()
+                .sorted(Comparator.comparing((Order order) -> order.getPayment().getPayDate()).reversed())
+                .map(OrderListResponse::of).toList();
+
         model.addAttribute("orders", orderResponses);
         return "usr/seller/orderList";
     }

--- a/src/main/resources/templates/usr/buyer/myOrder.html
+++ b/src/main/resources/templates/usr/buyer/myOrder.html
@@ -19,7 +19,13 @@
                 <a th:href="@{|/order/detail/${order.orderId}|}">
                     <div class="bg-base-100 border-b border-gray-200 p-5 ">
                         <div class="flex flex-col gap-1">
-                            <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>
+                            <div class="flex justify-between">
+                                <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>
+                                <span th:class="${order.primaryOrderStatus.priority <= 1 ? 'badge badge-info' :
+                                    (order.primaryOrderStatus.priority <= 3 ? 'badge badge-success' :
+                                    (order.primaryOrderStatus.priority == 4 ? 'badge badge-ghost' : 'badge badge-error'))}"
+                                      th:text="${order.primaryOrderStatus.value}"></span>
+                            </div>
                             <div th:text="${order.orderNumber}"
                                class="font-bold "></div>
                             <h3 th:text="${order.name}"></h3>

--- a/src/main/resources/templates/usr/buyer/myOrder.html
+++ b/src/main/resources/templates/usr/buyer/myOrder.html
@@ -15,10 +15,19 @@
             <div th:if="${orders.size() == 0}" class="flex justify-center my-16">
                 <span >주문 내역이 없습니다.</span>
             </div>
+            <div class="flex flex-grow justify-between p-5 mb-10">
+                <th:block th:each="status, statusIndex : ${orderStatuses}">
+                    <div class="flex flex-col justify-center items-center gap-2">
+                        <span th:text="${orderStatusCount.containsKey(status) ? orderStatusCount.get(status) : 0}"
+                              class="font-bold"></span>
+                        <span th:text="${status.value}" class="text-sm text-center"></span>
+                    </div>
+                </th:block>
+            </div>
             <div th:each="order, loop : ${orders}">
                 <a th:href="@{|/order/detail/${order.orderId}|}">
-                    <div class="bg-base-100 border-b border-gray-200 p-5 ">
-                        <div class="flex flex-col gap-1">
+                    <div th:class="'bg-base-100 border-b border-gray-200 p-5' + (${loop.first} ? ' border-t' : '')">
+                    <div class="flex flex-col gap-1">
                             <div class="flex justify-between">
                                 <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>
                                 <span th:class="${order.primaryOrderStatus.priority <= 1 ? 'badge badge-info' :

--- a/src/main/resources/templates/usr/cart/list.html
+++ b/src/main/resources/templates/usr/cart/list.html
@@ -20,7 +20,6 @@
                 <div th:if="${cartResponse.totalQuantity != 0}">
                     <div th:each="cartProduct, loop : ${cartResponse.cartProducts}">
                         <div class="bg-base-100 border-b border-gray-200 p-5 ">
-
                                 <div class="flex justify-around gap-5">
                                     <div class="border border-gray-200 w-2/6 p-5">
                                         이미지

--- a/src/main/resources/templates/usr/order/detail.html
+++ b/src/main/resources/templates/usr/order/detail.html
@@ -29,7 +29,10 @@
                                 <div class="flex flex-col gap-1">
                                     <div class="flex justify-between">
                                         <h3 th:text="${orderItem.product.seller.name}"></h3>
-                                        <span class="badge badge-ghost" th:text="${orderItem.orderStatus.value}"></span>
+                                        <span th:class="${orderItem.orderStatus.priority <= 1 ? 'badge badge-info' :
+                                                (orderItem.orderStatus.priority <= 3 ? 'badge badge-success' :
+                                                (orderItem.orderStatus.priority == 4 ? 'badge badge-ghost' : 'badge badge-error'))}"
+                                              th:text="${orderItem.orderStatus.value}"></span>
                                     </div>
                                     <a th:text="${orderItem.product.name}"
                                        class="font-bold"></a>

--- a/src/main/resources/templates/usr/order/management.html
+++ b/src/main/resources/templates/usr/order/management.html
@@ -29,7 +29,10 @@
                                 <div class="flex flex-col gap-1">
                                     <div class="flex justify-between">
                                         <h3 th:text="${orderItem.product.seller.name}"></h3>
-                                        <span class="badge badge-ghost" th:text="${orderItem.orderStatus.value}"></span>
+                                        <span th:class="${orderItem.orderStatus.priority <= 1 ? 'badge badge-info' :
+                                                    (orderItem.orderStatus.priority <= 3 ? 'badge badge-success' :
+                                                    (orderItem.orderStatus.priority == 4 ? 'badge badge-ghost' : 'badge badge-error'))}"
+                                              th:text="${orderItem.orderStatus.value}"></span>
                                     </div>
                                     <a th:text="${orderItem.product.name}"
                                        class="font-bold "></a>
@@ -40,14 +43,14 @@
                                           th:text="${#numbers.formatInteger(orderItem.product.price * orderItem.quantity, 0, 'COMMA') + '원'}"></span>
                                 </div>
                                 <form th:action="@{|/order/update/status/${orderItem.id}|}" method="POST"
-                                      class="flex gap-3">
+                                      class="flex gap-3 mt-5">
                                     <input type="hidden" name="orderId" th:value="${order.orderId}">
-                                    <select class="select select-bordered" name="newStatus">
-                                        <option th:each="orderStatus, loop : ${orderStatuses}"
+                                    <select class="select select-bordered w-3/4" name="newStatus">
+                                        <option th:each="orderStatus, loop : ${orderStatuses}" th:unless="${loop.index <= 1}"
                                                 th:value="${orderStatus.value}" th:text="${orderStatus.value}"
                                                 th:selected="${orderStatus.value.equals(orderItem.orderStatus.value)}"></option>
                                     </select>
-                                    <button class="btn" type="submit">변경</button>
+                                    <button class="btn btn-success w-1/4" type="submit">변경</button>
                                 </form>
                             </div>
                         </div>
@@ -55,23 +58,6 @@
                     </div>
                 </div>
 
-            </div>
-            <div class="flex flex-col gap-2">
-                <h3 class="text-lg font-bold mb-2 mt-10">주문 회원 정보</h3>
-                <div class="flex gap-2">
-                    <span class="w-1/4 text-gray-400">이름</span>
-                    <span th:text="${order.buyerName}"></span>
-                </div>
-                <div class="flex gap-2">
-                    <span class="w-1/4 text-gray-400">연락처</span>
-                    <span th:text="${order.deliveryAddress.phoneNumber}"></span>
-                </div>
-                <div class="flex gap-2">
-                    <span class="w-1/4 text-gray-400">배송지</span>
-                    <span class="w-3/4"
-                          th:text="'(' + ${order.deliveryAddress.postCode} + ') ' + ${order.deliveryAddress.address} + ' ' + ${order.deliveryAddress.detailAddress}">
-                        </span>
-                </div>
             </div>
             <div class="flex flex-col gap-2">
                 <h3 class="text-lg font-bold mb-2 mt-10">배송 정보</h3>
@@ -88,6 +74,13 @@
                     <span class="w-3/4"
                           th:text="'(' + ${order.deliveryAddress.postCode} + ') ' + ${order.deliveryAddress.address} + ' ' + ${order.deliveryAddress.detailAddress}">
                         </span>
+                </div>
+            </div>
+            <div class="flex flex-col gap-2">
+                <h3 class="text-lg font-bold mb-2 mt-10">주문 회원 정보</h3>
+                <div class="flex gap-2">
+                    <span class="w-1/4 text-gray-400">이름</span>
+                    <span th:text="${order.buyerName}"></span>
                 </div>
             </div>
             <div class="flex flex-col gap-2">

--- a/src/main/resources/templates/usr/order/management.html
+++ b/src/main/resources/templates/usr/order/management.html
@@ -46,7 +46,8 @@
                                       class="flex gap-3 mt-5">
                                     <input type="hidden" name="orderId" th:value="${order.orderId}">
                                     <select class="select select-bordered w-3/4" name="newStatus">
-                                        <option th:each="orderStatus, loop : ${orderStatuses}" th:unless="${loop.index <= 1}"
+                                        <option th:each="orderStatus, loop : ${orderStatuses}" th:unless="${loop.index < 1}"
+                                                th:disabled="${loop.index == 1}"
                                                 th:value="${orderStatus.value}" th:text="${orderStatus.value}"
                                                 th:selected="${orderStatus.value.equals(orderItem.orderStatus.value)}"></option>
                                     </select>

--- a/src/main/resources/templates/usr/question/list.html
+++ b/src/main/resources/templates/usr/question/list.html
@@ -12,8 +12,6 @@
             <span class="text-lg">영양제 복용, 건강관리 등에 대해 물어보세요!</span>
         </div>
 
-
-
         <div class="mb-9 sm:mb-16 !px-5" th:each="question, loop : ${questionList}">
             <div class="overflow-hidden">
                 <ul class="divide-y divide-gray-500/30 dark:divide-gray-500/70">

--- a/src/main/resources/templates/usr/seller/orderList.html
+++ b/src/main/resources/templates/usr/seller/orderList.html
@@ -19,10 +19,17 @@
                 <a th:href="@{|/order/management/${order.orderId}|}">
                     <div class="bg-base-100 border-b border-gray-200 p-5 ">
                         <div class="flex flex-col gap-1">
-                            <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>
+                            <div class="flex justify-between">
+                                <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>
+                                <span th:class="${order.primaryOrderStatus.priority <= 1 ? 'badge badge-info' :
+                                    (order.primaryOrderStatus.priority <= 3 ? 'badge badge-success' :
+                                    (order.primaryOrderStatus.priority == 4 ? 'badge badge-ghost' : 'badge badge-error'))}"
+                                      th:text="${order.primaryOrderStatus.value}"></span>
+                            </div>
                             <div th:text="${order.orderNumber}"
                                  class="font-bold "></div>
                             <h3 th:text="${order.name}"></h3>
+
                         </div>
                     </div>
                 </a>

--- a/src/main/resources/templates/usr/seller/orderList.html
+++ b/src/main/resources/templates/usr/seller/orderList.html
@@ -15,9 +15,19 @@
             <div th:if="${orders.size() == 0}" class="flex justify-center my-16">
                 <span >주문 내역이 없습니다.</span>
             </div>
+            <div class="flex flex-grow justify-between p-5 mb-10">
+                <th:block th:each="status, statusIndex : ${orderStatuses}">
+                    <div class="flex flex-col justify-center items-center gap-2">
+                        <span th:text="${orderStatusCount.containsKey(status) ? orderStatusCount.get(status) : 0}"
+                              class="font-bold"></span>
+                        <span th:text="${status.value}" class="text-sm text-center"></span>
+                    </div>
+                </th:block>
+            </div>
+
             <div th:each="order, loop : ${orders}">
                 <a th:href="@{|/order/management/${order.orderId}|}">
-                    <div class="bg-base-100 border-b border-gray-200 p-5 ">
+                    <div th:class="'bg-base-100 border-b border-gray-200 p-5' + (${loop.first} ? ' border-t' : '')">
                         <div class="flex flex-col gap-1">
                             <div class="flex justify-between">
                                 <span th:text="${#temporals.format(order.payment.payDate, 'yyyy-MM-dd')}"></span>


### PR DESCRIPTION
#### 📌 관련 이슈
- close #76

#### 📢 추가사항
- 주문의 대표 주문 상태 표시 
   - 주문 상품 중 가장 우선순위가 높은
   - 우선순위는 결제완료>상품준비중>배송전>배송중>배송완료
- 주문 내역 리스트 페이지에서 각 주문 상태 별 상품 개수 모아보기
- 주문 내역 리스트 최신순으로 정렬

#### 🔔 변경사항
- 

#### 🔎 특이사항
- 
