### PR TITLE
Fix: 복약 관리 회원 수정

### DIFF
--- a/src/main/java/com/mypill/domain/diary/entity/Diary.java
+++ b/src/main/java/com/mypill/domain/diary/entity/Diary.java
@@ -53,6 +53,7 @@ public class Diary extends BaseEntity {
         return DiaryCheckLog.builder()
                 .diary(this)
                 .checkDate(now)
+                .member(member)
                 .build();
     }
 

--- a/src/main/java/com/mypill/domain/member/entity/Member.java
+++ b/src/main/java/com/mypill/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.joda.time.DateTime;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 

--- a/src/main/resources/templates/usr/product/list.html
+++ b/src/main/resources/templates/usr/product/list.html
@@ -82,7 +82,7 @@
 
                     <div class="flex justify-around gap-5">
                         <div class="border border-gray-200 w-2/6">
-                            <img th:src="${product.image != null ? product.image.filepath : '/'}" alt="product_image" style="width: 3000px; height: 100px;" />
+                            <img th:src="${product.image != null ? product.image.filepath : '/'}" alt="product_image" style="width: 100px; height: 100px;" />
                         </div>
                         <div class="flex flex-col gap-3 w-4/6">
                             <div class="flex flex-col gap-1">

--- a/src/test/java/com/mypill/domain/diary/service/DiaryServiceTest.java
+++ b/src/test/java/com/mypill/domain/diary/service/DiaryServiceTest.java
@@ -1,0 +1,74 @@
+package com.mypill.domain.diary.service;
+
+
+import com.mypill.domain.diary.entity.Diary;
+import com.mypill.domain.diary.entity.DiaryCheckLog;
+import com.mypill.domain.diary.repository.DiaryCheckLogRepository;
+import com.mypill.domain.diary.repository.DiaryRepository;
+import com.mypill.domain.member.entity.Member;
+import com.mypill.domain.member.service.MemberService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.MethodName.class)
+class DiaryServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+    private Member testUser1;
+    private Diary diary;
+    @Autowired
+    private DiaryRepository diaryRepository;
+    @Autowired
+    private DiaryService diaryService;
+    private Diary savedDiary;
+    @Autowired
+    private DiaryCheckLogRepository diaryCheckLogRepository;
+
+    @BeforeEach
+    void beforeEachTest() {
+        testUser1 = memberService.join("testUserSeller1", "김철수", "1234", 2, "testSeller1@test.com").getData();
+        diary = Diary.builder()
+                .member(testUser1)
+                .name("루테인")
+                .time("morning")
+                .type("간")
+                .memo("x")
+                .build();
+        savedDiary = diaryRepository.save(diary);
+
+        DiaryCheckLog diaryCheckLog = DiaryCheckLog.builder()
+                .diary(savedDiary)
+                .member(testUser1)
+                .checkDate(LocalDate.now())
+                .build();
+        diaryCheckLogRepository.save(diaryCheckLog);
+    }
+
+    @Test
+    @DisplayName("당일 날짜에 해당하는 체크한 기록 불러오기")
+    void findHistoryTests() {
+        LocalDate currentDate = LocalDate.of(2023, 7, 9);
+        List<Diary> history = diaryService.findHistory(testUser1, LocalDate.now());
+        List<Diary> history1 = diaryService.findHistory(testUser1, currentDate);
+
+        assertThat(history1.size()).isEqualTo(0);
+        assertThat(history.size()).isEqualTo(1);
+
+    }
+
+}
+


### PR DESCRIPTION
#### 📌 관련 이슈
- 복약 관리 memberId 저장 안되던 부분 추가
- history Test 추가

#### 📢 추가사항
- 

#### 🔔 변경사항
- 

#### 🔎 특이사항
- 
